### PR TITLE
fix: NEXUS-632: runner monitor - fix eventwatch rule naming

### DIFF
--- a/modules/runners/runner-monitor.tf
+++ b/modules/runners/runner-monitor.tf
@@ -98,7 +98,7 @@ resource "aws_iam_role_policy" "monitor_ami_id_ssm_parameter_read" {
 }
 
 resource "aws_cloudwatch_event_rule" "run_monitor" {
-  name                = "run-monitor"
+  name                = "${var.prefix}-run-monitor"
   description         = "Check for jobs in orgs with no runners"
   schedule_expression = var.runner_monitor_chron
 }

--- a/modules/runners/runner-monitor.tf
+++ b/modules/runners/runner-monitor.tf
@@ -98,7 +98,7 @@ resource "aws_iam_role_policy" "monitor_ami_id_ssm_parameter_read" {
 }
 
 resource "aws_cloudwatch_event_rule" "run_monitor" {
-  name                = "${var.prefix}-run-monitor"
+  name                = "run-${var.prefix}-runner-monitor"
   description         = "Check for jobs in orgs with no runners"
   schedule_expression = var.runner_monitor_chron
 }


### PR DESCRIPTION
Eventwatch rules can only have 5 targets - let's just make a rule for each lambda.